### PR TITLE
README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,14 @@
-# 369origins-ads-file
+# Xác minh quảng cáo cho ứng dụng 369 Origins
 
-Repo này được tạo để chứa file **app-ads.txt** và nội dung phục vụ xác minh quảng cáo (AdMob) cho ứng dụng **369 Origins**.
-
----
-
-## 📂 Nội dung repo
-- `index.html` → Trang chính hiển thị khi truy cập GitHub Pages.
-- `app-ads.txt` → File xác minh AdMob, cần đặt ở root để Google có thể crawl.
-- `README.md` → File mô tả dự án.
-
----
+Repo này phục vụ file `app-ads.txt` tại đúng vị trí gốc của GitHub Pages để xác minh quyền sở hữu ứng dụng **369 Origins** với các nền tảng quảng cáo như AdMob.
 
 ## 🔗 Liên kết quan trọng
-- Trang GitHub Pages: [https://qatashop1-spec.github.io/369origins-ads-file/](https://qatashop1-spec.github.io/369origins-ads-file/)
-- File app-ads.txt: [https://qatashop1-spec.github.io/369origins-ads-file/app-ads.txt](https://qatashop1-spec.github.io/369origins-ads-file/app-ads.txt)
+- File xác minh: [https://qatashop1-spec.github.io/app-ads.txt](https://qatashop1-spec.github.io/app-ads.txt)
 
----
-
-## ℹ️ Ghi chú
-- File **app-ads.txt** bắt buộc phải có trong root để AdMob xác minh.  
-- Nếu cần bổ sung thêm seller cho quảng cáo, chỉ cần chỉnh sửa file `app-ads.txt` và commit lại.
-
----
+## 📂 Nội dung repo
+- `app-ads.txt` → File xác minh quảng cáo
+- `index.html`, `page.html` → Trang hiển thị tùy chỉnh
+- `README.md` → Mô tả repo
 
 ## 👨‍💻 Tác giả
 - Chủ sở hữu: **qatashop1-spec**


### PR DESCRIPTION
# app-ads.txt cho ứng dụng 369 Origins

Repo này được sử dụng để phục vụ file **app-ads.txt** tại đúng vị trí gốc của GitHub Pages, nhằm xác minh quyền sở hữu ứng dụng **369 Origins** với các nền tảng quảng cáo như AdMob.

---

## 📂 Nội dung repo
- `app-ads.txt` → File xác minh AdMob, nằm tại root để Google có thể crawl.
- `README.md` → Mô tả repo và mục đích sử dụng.

---

## 🔗 Liên kết quan trọng
- File app-ads.txt: [https://qatashop1-spec.github.io/app-ads.txt](https://qatashop1-spec.github.io/app-ads.txt)

---

## ℹ️ Ghi chú
- File **app-ads.txt** cần nằm ở thư mục gốc của GitHub Pages để xác minh hợp lệ.
- Nếu cần bổ sung thêm seller cho quảng cáo, chỉ cần chỉnh sửa file `app-ads.txt` và commit lại.

---

## 👨‍💻 Tác giả
- Chủ sở hữu: **qatashop1-spec**
- Dự án: **369 Origins**
